### PR TITLE
Upgrade CodeSniffer to 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Denis Uraganov <github@uraganov.net>
 
 RUN echo "phar.readonly = 0" >> /usr/local/etc/php/php.ini
 RUN composer self-update
-RUN composer create-project --no-dev "squizlabs/php_codesniffer=3.0.*@dev"
+RUN composer create-project --no-dev "squizlabs/php_codesniffer=3.2.2"
 RUN php php_codesniffer/scripts/build-phar.php
 RUN chmod +x *.phar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM denisura/composer
 MAINTAINER Denis Uraganov <github@uraganov.net>
 
 RUN echo "phar.readonly = 0" >> /usr/local/etc/php/php.ini
-
-RUN composer create-project "squizlabs/php_codesniffer=2.0.*@dev"
+RUN composer self-update
+RUN composer create-project --no-dev "squizlabs/php_codesniffer=3.0.*@dev"
 RUN php php_codesniffer/scripts/build-phar.php
 RUN chmod +x *.phar
 


### PR DESCRIPTION
+ Skip dev requirements when creating composer project
+ Ensure composer is always the latest version _before_ creating the CS project
+ Bump CS from 2.0 to 3.0.x